### PR TITLE
Título: feat: cambiar campo de login a email y limpiar campos al regresar

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,17 +33,19 @@
 
                 <form class="login-form" id="loginForm" novalidate>
 
-                    <!-- Campo: número de documento -->
+                    <!-- Campo de correo electrónico — reemplaza al campo de documento -->
+                    <!-- El login ahora usa email + contraseña en lugar de documento + contraseña -->
+                    <!-- El id cambia a loginEmail para que los listeners en modoUI.js funcionen -->
                     <div class="form__group">
-                        <label for="loginDocumento" class="form__label">Número de documento</label>
+                        <label for="loginEmail" class="form__label">Correo electrónico</label>
                         <input
                             type="text"
-                            id="loginDocumento"
+                            id="loginEmail"
                             class="form__input"
-                            placeholder="Ej: 1097497001"
-                            autocomplete="username"
+                            placeholder="ejemplo@correo.com"
+                            autocomplete="email"
                         >
-                        <span class="form__error" id="loginDocumentoError"></span>
+                        <span class="form__error" id="loginEmailError"></span>
                     </div>
 
                     <!-- Campo: contraseña con botón para mostrar/ocultar -->

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -10,18 +10,21 @@
 
 import { API_BASE_URL, API_PREFIX } from '../utils/config.js';
 
-// ── LOGIN ─────────────────────────────────────────────────────────────────────
+// ── LOGIN (ACTUALIZADO) ───────────────────────────────────────────────────────
 // POST /api/auth/login
-// Cuerpo esperado: { documento, password }
-// Respuesta exitosa: { accessToken, refreshToken, user: { id, name, role } }
-// Lanza un Error si el servidor responde un status de error, para que el
-// llamador (modoUI.js) pueda mostrarlo con SweetAlert2.
-export async function loginUsuario({ documento, password }) {
+// Cuerpo esperado: { email, password }  ← CAMBIO: antes era { documento, password }
+// Respuesta exitosa: { accessToken, refreshToken, user: { id, name, role, documento } }
+//
+// El backend (auth.service.js de Sebastian) ahora busca el usuario por email.
+// El token JWT sigue incluyendo { id, documento, role } en el payload,
+// así que el resto del frontend no necesita cambios.
+export async function loginUsuario({ email, password }) {
     const url = `${API_BASE_URL}${API_PREFIX}/auth/login`;
     const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ documento, password }),
+        // CAMBIO: se envía email en lugar de documento
+        body: JSON.stringify({ email, password }),
     });
     const json = await response.json();
     if (!response.ok) throw new Error(json.error || json.message || 'Credenciales incorrectas');

--- a/src/ui/modoUI.js
+++ b/src/ui/modoUI.js
@@ -62,6 +62,9 @@ export function activarModoInicio() {
     ocultarTodo();
     pantallaInicio.classList.remove('hidden');
     document.body.dataset.modo = 'inicio';
+    // Limpiar los campos del formulario para no exponer datos del usuario anterior
+    // Esto es especialmente importante en computadores compartidos
+    limpiarFormularioLogin();
 }
 
 export function activarModoUsuario() {
@@ -1105,6 +1108,46 @@ function obtenerIdsSeleccionados() {
     });
 }
 
+// ── LIMPIAR FORMULARIO DE LOGIN ───────────────────────────────────────────────
+// Limpia los campos de email y contraseña del formulario de login,
+// oculta el mensaje de bienvenida y quita los mensajes de error visibles.
+//
+// Se llama desde activarModoInicio() y desde manejarCerrarSesion()
+// para garantizar que cuando el usuario vuelve a la pantalla de inicio
+// no vea los datos del usuario anterior en los campos.
+// Esto es crítico en entornos compartidos: un segundo usuario no debe
+// ver el email del usuario anterior si este no cerró el navegador.
+function limpiarFormularioLogin() {
+    // Limpiar el campo de email
+    const inputEmail = document.getElementById('loginEmail');
+    if (inputEmail) inputEmail.value = '';
+
+    // Limpiar el campo de contraseña
+    const inputPassword = document.getElementById('loginPassword');
+    if (inputPassword) inputPassword.value = '';
+
+    // Resetear el botón del ojo (mostrar/ocultar contraseña) a su estado inicial
+    if (inputPassword) inputPassword.type = 'password';
+    const btnToggle = document.getElementById('btnTogglePassword');
+    if (btnToggle) btnToggle.textContent = '👁️';
+
+    // Ocultar el mensaje de bienvenida post-login si está visible
+    // El mensaje dice "Sesión iniciada · [nombre]" y debe desaparecer al volver
+    const bienvenidaDiv = document.getElementById('loginBienvenida');
+    if (bienvenidaDiv) bienvenidaDiv.classList.add('hidden');
+
+    // Limpiar los spans de error para que no queden mensajes visibles
+    const errorEmail = document.getElementById('loginEmailError');
+    if (errorEmail) errorEmail.textContent = '';
+
+    const errorPassword = document.getElementById('loginPasswordError');
+    if (errorPassword) errorPassword.textContent = '';
+
+    // Quitar la clase 'error' de los inputs si quedaron marcados en rojo
+    if (inputEmail)    inputEmail.classList.remove('error');
+    if (inputPassword) inputPassword.classList.remove('error');
+}
+
 // ── REGISTRO DE EVENTOS DE NAVEGACIÓN ────────────────────────────────────────
 
 export function registrarEventosNavegacion() {
@@ -1114,9 +1157,9 @@ export function registrarEventosNavegacion() {
 
     // ── FORMULARIO DE LOGIN ───────────────────────────────────────────────────────
     const formLogin       = document.getElementById('loginForm');
-    const inputDocumento  = document.getElementById('loginDocumento');
+    const inputEmail     = document.getElementById('loginEmail');              // Se cambia el id de loginDocumento a loginEmail para que coincida con el HTML actualizado
     const inputPassword   = document.getElementById('loginPassword');
-    const errorDocumento  = document.getElementById('loginDocumentoError');
+    const errorEmail     = document.getElementById('loginEmailError');
     const errorPassword   = document.getElementById('loginPasswordError');
     const bienvenidaDiv   = document.getElementById('loginBienvenida');
     const bienvenidaTexto = document.getElementById('loginBienvenidaTexto');
@@ -1139,10 +1182,10 @@ export function registrarEventosNavegacion() {
             // validarFormularioLogin valida ambos campos con el mismo patrón del proyecto:
             // muestra el error en el span del input Y como toast con SweetAlert2.
             // Retorna false si algo falla — en ese caso no llamamos al servidor.
-            const esValido = await validarFormularioLogin({
-                docInput:      inputDocumento,
+             const esValido = await validarFormularioLogin({
+                emailInput:    inputEmail,      // ← antes era docInput: inputDocumento
                 passwordInput: inputPassword,
-                docError:      errorDocumento,
+                emailError:    errorEmail,      // ← antes era docError: errorDocumento
                 passwordError: errorPassword,
             });
             if (!esValido) return;
@@ -1154,9 +1197,9 @@ export function registrarEventosNavegacion() {
             try {
                 // Llamada al backend — si falla lanza un Error con el mensaje del servidor
                 const datos = await loginUsuario({
-                    documento: inputDocumento.value.trim(),
-                    password:  inputPassword.value,
-                });
+                email:    inputEmail.value.trim(),     // ← antes era documento
+                password: inputPassword.value,
+            })
 
                 // Guardar tokens y datos del usuario en localStorage
                 guardarSesion(datos);
@@ -1164,8 +1207,7 @@ export function registrarEventosNavegacion() {
                 // Mostrar saludo personalizado con el rol
                 const etiquetaRol = datos.user.role === 'admin' ? 'Administrador' : 'Usuario';
                 if (bienvenidaDiv && bienvenidaTexto) {
-                    bienvenidaTexto.textContent =
-                        `¡Bienvenido, ${datos.user.name}! Ingresando como ${etiquetaRol}...`;
+                    bienvenidaTexto.textContent = `Sesión iniciada · ${datos.user.name}`;
                     bienvenidaDiv.classList.remove('hidden');
                 }
 

--- a/src/utils/validaciones.js
+++ b/src/utils/validaciones.js
@@ -183,43 +183,40 @@ export async function validarFormularioTarea({ titleInput, statusInput, titleErr
     return esValido;
 }
 
-// ── VALIDACIÓN FORMULARIO LOGIN ───────────────────────────────────────────────
-// Mensajes alineados con lo que devuelve el backend en auth.controller.js.
-// Sigue el mismo patrón que validarFormularioUsuario y validarFormularioTarea:
-// muestra el error en el span del campo Y como toast con mostrarNotificacion().
-// Retorna true si ambos campos son válidos.
+// ── VALIDACIÓN FORMULARIO LOGIN (ACTUALIZADA) ─────────────────────────────────
+// Antes validaba documento (solo números, mínimo 5 caracteres).
+// Ahora valida email (formato correo, máximo 100 caracteres).
 //
-// Reglas del documento: mismas que createUserSchema del backend (user.schema.js).
-// Reglas de la contraseña: mínimo 6 caracteres.
-export async function validarFormularioLogin({ docInput, passwordInput, docError, passwordError }) {
+// Los mensajes de error están en español y aparecen tanto en el span del campo
+// como en un toast de SweetAlert2 (mostrarNotificacion).
+// Retorna true si ambos campos son válidos, false si hay algún error.
+export async function validarFormularioLogin({ emailInput, passwordInput, emailError, passwordError }) {
     let esValido      = true;
     let primerMensaje = null;
 
-    // Limpiar errores previos en los dos campos
-    [docError, passwordError].forEach(el => { if (el) el.textContent = ''; });
-    [docInput, passwordInput].forEach(el => { if (el) el.classList.remove('error'); });
+    // Limpiar errores previos en los dos campos para que no se acumulen
+    [emailError, passwordError].forEach(el => { if (el) el.textContent = ''; });
+    [emailInput, passwordInput].forEach(el => { if (el) el.classList.remove('error'); });
 
-    // ── Validar documento ────────────────────────────────────────────────────
-    const valorDoc = docInput ? docInput.value.trim() : '';
+    // ── Validar email ────────────────────────────────────────────────────────
+    // Se valida manualmente con regex en lugar de depender del type="email"
+    // para controlar el mensaje y el estilo del error
+    const valorEmail = emailInput ? emailInput.value.trim() : '';
 
-    if (!entradaEsValida(valorDoc)) {
-        const msg = 'El número de documento es obligatorio';
-        mostrarError(docError, docInput, msg);
+    if (!entradaEsValida(valorEmail)) {
+        const msg = 'El correo electrónico es obligatorio';
+        mostrarError(emailError, emailInput, msg);
         if (!primerMensaje) primerMensaje = msg;
         esValido = false;
-    } else if (!/^\d+$/.test(valorDoc)) {
-        const msg = 'El documento solo puede contener números';
-        mostrarError(docError, docInput, msg);
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(valorEmail)) {
+        // El regex verifica que haya texto antes del @, el @ en sí, y texto con punto después
+        const msg = 'El correo electrónico no tiene un formato válido';
+        mostrarError(emailError, emailInput, msg);
         if (!primerMensaje) primerMensaje = msg;
         esValido = false;
-    } else if (valorDoc.length < 5) {
-        const msg = 'El documento debe tener al menos 5 caracteres';
-        mostrarError(docError, docInput, msg);
-        if (!primerMensaje) primerMensaje = msg;
-        esValido = false;
-    } else if (valorDoc.length > 20) {
-        const msg = 'El documento no puede exceder los 20 caracteres';
-        mostrarError(docError, docInput, msg);
+    } else if (valorEmail.length > 100) {
+        const msg = 'El correo no puede exceder los 100 caracteres';
+        mostrarError(emailError, emailInput, msg);
         if (!primerMensaje) primerMensaje = msg;
         esValido = false;
     }
@@ -239,6 +236,7 @@ export async function validarFormularioLogin({ docInput, passwordInput, docError
         esValido = false;
     }
 
+    // Mostrar el primer error como toast de SweetAlert2
     if (primerMensaje) await mostrarNotificacion(primerMensaje, 'error');
 
     return esValido;


### PR DESCRIPTION
## Descripción del Cambio
Se actualiza el formulario de login para que use email en lugar de número de
documento, alineando el frontend con el cambio en el backend (Issue B-2).
Se agrega limpieza automática de los campos al volver a la pantalla de inicio
y se mejora el mensaje de bienvenida post-login.

## Tipo de Cambio
- [x] feat: Nueva funcionalidad

## Relación con Tareas
Closes #75 

## Checklist de Calidad Universal
- [x] Sincronización: he hecho git pull origin release antes de este PR
- [x] Limpieza: sin console.log ni comentarios de prueba
- [x] Estándares: nombres en camelCase, comentarios en español

### Validación FRONTEND
- [x] Responsive: probado en móvil y escritorio
- [x] Sin errores en consola del navegador
- [x] Login con email funciona correctamente
- [x] Al hacer logout los campos quedan vacíos
- [x] El mensaje de bienvenida es profesional

## Evidencia de Trabajo
<img width="987" height="878" alt="imagen" src="https://github.com/user-attachments/assets/fab151ce-c1e1-47f8-b9e0-6e6322df7216" />


## Archivos modificados
- index.html (campo loginDocumento → loginEmail)
- src/api/authApi.js (loginUsuario envía email)
- src/utils/validaciones.js (validarFormularioLogin valida email)
- src/ui/modoUI.js (variables actualizadas, limpiarFormularioLogin agregada)

