### PR TITLE
fix(auth): redirigir correctamente a panel instructor al hacer login

### DIFF
--- a/src/ui/modoUI.js
+++ b/src/ui/modoUI.js
@@ -1917,9 +1917,17 @@ export function registrarEventosNavegacion() {
                 await new Promise(resolve => setTimeout(resolve, 1200));
 
                 // Redirigir al modo que corresponde según el rol del usuario
+                // Se evalúan los 3 roles posibles: admin, instructor y user
+                // Sin este bloque completo, el instructor aterrizaba en la vista de usuario
                 if (datos.user.role === 'admin') {
+                    // El rol admin activa el panel de administración con CRUD completo
                     await activarModoAdmin();
+                } else if (datos.user.role === 'instructor') {
+                    // El rol instructor activa el panel docente con paleta verde
+                    // Esta línea faltaba — causaba que instructor viera la vista de usuario
+                    await activarModoInstructor();
                 } else {
+                    // El rol user activa el panel personal con solo sus tareas
                     activarModoUsuario();
                 }
 


### PR DESCRIPTION
## Descripción del Cambio
El bloque if/else del formulario de login solo manejaba los casos 'admin' y el resto como usuario normal. Se agrega la condición para 'instructor' que llama a activarModoInstructor() directamente, evitando el paso intermedio por la vista de usuario.

## Tipo de Cambio
- [ ] **feat**: Nueva funcionalidad.
- [x] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #98 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** He actualizado mi rama con `origin/develop` y resolví conflictos.
- [x] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [x] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.

### Validación FRONTEND (Si aplica)
- [x] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [x] Sin errores en consola del navegador

### Validación BACKEND (Si aplica)
- [ ] **Endpoints:** He probado las rutas en Postman/Thunder Client y retornan el código HTTP correcto.
- [ ] **Validación:** Se implementó manejo de errores (try/catch) y validación de datos de entrada.
- [ ] **Modelos:** Los cambios en la base de datos o modelos fueron comunicados al equipo.

---

## Evidencia de Trabajo
[Adjuntar captura del panel instructor cargando directamente tras login sin necesidad de F5]
<img width="1914" height="868" alt="image" src="https://github.com/user-attachments/assets/689345c1-7f31-4988-bbed-eb0dec673285" />


## Archivos modificados
- src/ui/modoUI.js