### PR TITLE
feat: registro rediseñado y boton de editar en vista de instructor, funcional

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,92 +746,124 @@
     </div>
 </div>
 
-<!-- MODAL DE REGISTRO -->
-<!-- Se muestra como overlay encima de la pantalla de inicio al hacer clic en "Regístrate" -->
-<!-- Tiene el mismo estilo glass que la card del login para coherencia visual -->
+<!-- MODAL DE REGISTRO — Rediseñado en M7 -->
+<!-- Conserva los mismos IDs en todos los campos para no romper la lógica de modoUI.js -->
+<!-- Solo cambia el HTML estructural y las clases CSS — la funcionalidad es idéntica -->
 <div class="modal-overlay hidden" id="registroModal">
-    <div class="modal modal--registro">
+    <div class="modal modal--registro modal--registro-v2">
 
-        <!-- Encabezado del modal con título y botón de cierre -->
-        <div class="modal__header">
-            <h2 class="modal__title">Crear cuenta</h2>
-            <button class="modal__close" id="registroCloseBtn" type="button">✕</button>
+        <!-- Encabezado con ícono y título estilizado -->
+        <div class="modal--registro-v2__header">
+            <!-- Ícono de usuario que da identidad visual al modal -->
+            <div class="modal--registro-v2__icono" aria-hidden="true">👤</div>
+            <div>
+                <h2 class="modal--registro-v2__titulo">Crear cuenta</h2>
+                <p class="modal--registro-v2__subtitulo">Completa los datos para registrarte</p>
+            </div>
+            <!-- Botón de cierre — mismo ID que antes para que modoUI.js lo encuentre -->
+            <button class="modal--registro-v2__cerrar" id="registroCloseBtn" type="button" aria-label="Cerrar modal de registro">✕</button>
         </div>
 
-        <!-- Formulario de registro con validaciones en cada campo -->
-        <form id="registroForm" class="form" novalidate>
+        <!-- Formulario de registro — mismos IDs de campos que antes -->
+        <form id="registroForm" class="modal--registro-v2__form" novalidate>
 
-            <!-- Campo nombre: solo letras y espacios, mínimo 3 caracteres -->
-            <div class="form__group">
-                <label for="registroNombre" class="form__label">Nombre completo</label>
-                <input
-                    type="text"
-                    id="registroNombre"
-                    class="form__input"
-                    placeholder="Ej: María López"
-                    autocomplete="name"
-                >
-                <span class="form__error" id="registroNombreError"></span>
+            <!-- Fila 1: Nombre y Documento en dos columnas -->
+            <div class="modal--registro-v2__fila">
+
+                <!-- Campo nombre: solo letras y espacios, mínimo 3 caracteres -->
+                <div class="modal--registro-v2__grupo">
+                    <label for="registroNombre" class="modal--registro-v2__label">
+                        Nombre completo
+                    </label>
+                    <input
+                        type="text"
+                        id="registroNombre"
+                        class="modal--registro-v2__input"
+                        placeholder="María López"
+                        autocomplete="name"
+                    >
+                    <span class="modal--registro-v2__error" id="registroNombreError"></span>
+                </div>
+
+                <!-- Campo documento: solo números, mínimo 5 dígitos -->
+                <div class="modal--registro-v2__grupo">
+                    <label for="registroDocumento" class="modal--registro-v2__label">
+                        Documento
+                    </label>
+                    <input
+                        type="text"
+                        id="registroDocumento"
+                        class="modal--registro-v2__input"
+                        placeholder="1097497124"
+                        autocomplete="off"
+                    >
+                    <span class="modal--registro-v2__error" id="registroDocumentoError"></span>
+                </div>
+
             </div>
 
-            <!-- Campo documento: solo números, mínimo 5 dígitos -->
-            <div class="form__group">
-                <label for="registroDocumento" class="form__label">Número de documento</label>
-                <input
-                    type="text"
-                    id="registroDocumento"
-                    class="form__input"
-                    placeholder="Ej: 1097497124"
-                    autocomplete="off"
-                >
-                <span class="form__error" id="registroDocumentoError"></span>
-            </div>
-
-            <!-- Campo email: debe tener @ y dominio válido -->
-            <div class="form__group">
-                <label for="registroEmail" class="form__label">Correo electrónico</label>
+            <!-- Fila 2: Email en ancho completo -->
+            <div class="modal--registro-v2__grupo">
+                <label for="registroEmail" class="modal--registro-v2__label">
+                    Correo electrónico
+                </label>
                 <input
                     type="text"
                     id="registroEmail"
-                    class="form__input"
+                    class="modal--registro-v2__input"
                     placeholder="ejemplo@correo.com"
                     autocomplete="email"
                 >
-                <span class="form__error" id="registroEmailError"></span>
+                <span class="modal--registro-v2__error" id="registroEmailError"></span>
             </div>
 
-            <!-- Campo contraseña: mínimo 6 caracteres -->
-            <div class="form__group">
-                <label for="registroPassword" class="form__label">Contraseña</label>
-                <input
-                    type="password"
-                    id="registroPassword"
-                    class="form__input"
-                    placeholder="Mínimo 6 caracteres"
-                    autocomplete="new-password"
-                >
-                <span class="form__error" id="registroPasswordError"></span>
+            <!-- Fila 3: Contraseña y Confirmar contraseña en dos columnas -->
+            <div class="modal--registro-v2__fila">
+
+                <!-- Campo contraseña: mínimo 6 caracteres -->
+                <div class="modal--registro-v2__grupo">
+                    <label for="registroPassword" class="modal--registro-v2__label">
+                        Contraseña
+                    </label>
+                    <input
+                        type="password"
+                        id="registroPassword"
+                        class="modal--registro-v2__input"
+                        placeholder="Mínimo 6 caracteres"
+                        autocomplete="new-password"
+                    >
+                    <span class="modal--registro-v2__error" id="registroPasswordError"></span>
+                </div>
+
+                <!-- Campo confirmar contraseña: debe coincidir con el campo anterior -->
+                <div class="modal--registro-v2__grupo">
+                    <label for="registroConfirmar" class="modal--registro-v2__label">
+                        Confirmar
+                    </label>
+                    <input
+                        type="password"
+                        id="registroConfirmar"
+                        class="modal--registro-v2__input"
+                        placeholder="Repite la contraseña"
+                        autocomplete="new-password"
+                    >
+                    <span class="modal--registro-v2__error" id="registroConfirmarError"></span>
+                </div>
+
             </div>
 
-            <!-- Campo confirmar contraseña: debe coincidir con el campo anterior -->
-            <div class="form__group">
-                <label for="registroConfirmar" class="form__label">Confirmar contraseña</label>
-                <input
-                    type="password"
-                    id="registroConfirmar"
-                    class="form__input"
-                    placeholder="Repite tu contraseña"
-                    autocomplete="new-password"
-                >
-                <span class="form__error" id="registroConfirmarError"></span>
-            </div>
-
-            <!-- Botón de envío del formulario de registro -->
-            <button type="submit" class="btn-acceso btn-acceso--login" id="btnRegistrar">
+            <!-- Botón de envío — mismo ID que antes para que modoUI.js lo encuentre -->
+            <button type="submit" class="modal--registro-v2__btn-submit" id="btnRegistrar">
                 Crear cuenta
             </button>
 
+            <!-- Nota de privacidad -->
+            <p class="modal--registro-v2__nota">
+                Tus datos solo se usan para acceder al sistema. No los compartimos con terceros.
+            </p>
+
         </form>
+
     </div>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "sweetalert2": "^11.26.20"
+        "sweetalert2": "^11.26.20",
+        "toastify-js": "^1.12.0"
       },
       "devDependencies": {
         "vite": "^7.3.1"
@@ -1039,6 +1040,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/toastify-js": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
+      "integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "vite": "^7.3.1"
   },
   "dependencies": {
-    "sweetalert2": "^11.26.20"
+    "sweetalert2": "^11.26.20",
+    "toastify-js": "^1.12.0"
   }
 }

--- a/src/ui/modoUI.js
+++ b/src/ui/modoUI.js
@@ -20,7 +20,7 @@ import {
     obtenerTodosLosUsuarios,
     eliminarUsuario,
     actualizarUsuario,
-    cambiarRolUsuario,          // ← nueva función
+    cambiarRolUsuario,
     cambiarPassword,
 } from '../api/usuariosApi.js';
 
@@ -1019,7 +1019,68 @@ function manejarEdicionTareaAdmin(tarea) {
 
     formulario.addEventListener('submit', guardarCambiosAdmin);
 }
+// manejarEdicionTareaInstructor — abre el modal compartido de edición para el instructor.
+// Diferencia con manejarEdicionTareaAdmin:
+//   - Al guardar, recarga cargarTareasInstructor() y cargarDashboardInstructor()
+//   - No actualiza todasLasTareas (esa variable es privada del panel admin)
+// Usa el mismo modal editModal y el mismo formulario editTaskForm del index.html.
+function manejarEdicionTareaInstructor(tarea) {
+    // Abrir el modal con los datos de la tarea precargados
+    // mostrarModalEdicion viene de tareasUI.js y rellena los campos del formulario
+    mostrarModalEdicion(tarea);
 
+    // Referencia al formulario compartido de edición
+    const formulario = document.getElementById('editTaskForm');
+    if (!formulario) return;
+
+    // Función que se ejecuta al guardar los cambios desde el instructor
+    // Se define como función nombrada para poder removerla después del submit
+    // y evitar que se acumule un listener por cada edición
+    async function guardarCambiosInstructor(event) {
+        event.preventDefault();
+
+        // Leer los valores actuales del formulario de edición
+        const tareaId     = document.getElementById('editTaskId').value;
+        const titulo      = document.getElementById('editTaskTitle').value.trim();
+        const descripcion = document.getElementById('editTaskDescription').value.trim();
+        const estado      = document.getElementById('editTaskStatus').value;
+
+        // El campo comentario puede no existir en todos los formularios de edición
+        const comentEl   = document.getElementById('editTaskComment');
+        const comentario = comentEl && comentEl.value.trim() !== ''
+            ? comentEl.value.trim()
+            : null;
+
+        // Construir el objeto con los datos actualizados
+        const datosActualizados = {
+            title:       titulo,
+            description: descripcion,
+            status:      estado,
+            comment:     comentario,
+        };
+
+        // Llamar al backend para actualizar la tarea
+        const tareaActualizada = await actualizarTarea(tareaId, datosActualizados);
+
+        if (tareaActualizada) {
+            // Cerrar el modal y recargar las tablas del instructor
+            ocultarModalEdicion();
+            // Se recargan ambas tablas para reflejar los cambios de forma consistente
+            cargarTareasInstructor();
+            cargarDashboardInstructor();
+            await mostrarNotificacion('Tarea actualizada exitosamente', 'exito');
+        } else {
+            await mostrarNotificacion('Error al actualizar la tarea', 'error');
+        }
+
+        // Remover el listener después de ejecutarse para evitar duplicados
+        // en la próxima edición desde el panel instructor
+        formulario.removeEventListener('submit', guardarCambiosInstructor);
+    }
+
+    // Registrar el listener del submit para esta edición del instructor
+    formulario.addEventListener('submit', guardarCambiosInstructor);
+}           
 
 function crearFilaTareaAdmin(tarea, indice) {
     const fila = document.createElement('tr');

--- a/src/ui/modoUI.js
+++ b/src/ui/modoUI.js
@@ -1020,68 +1020,6 @@ function manejarEdicionTareaAdmin(tarea) {
     formulario.addEventListener('submit', guardarCambiosAdmin);
 }
 
-// manejarEdicionTareaInstructor — abre el modal compartido de edición para el instructor.
-// Diferencia con manejarEdicionTareaAdmin:
-//   - Al guardar, recarga cargarTareasInstructor() y cargarDashboardInstructor()
-//   - No actualiza todasLasTareas (esa variable es privada del panel admin)
-// Usa el mismo modal editModal y el mismo formulario editTaskForm del index.html.
-function manejarEdicionTareaInstructor(tarea) {
-    // Abrir el modal con los datos de la tarea precargados
-    // mostrarModalEdicion viene de tareasUI.js y rellena los campos del formulario
-    mostrarModalEdicion(tarea);
-
-    // Referencia al formulario compartido de edición
-    const formulario = document.getElementById('editTaskForm');
-    if (!formulario) return;
-
-    // Función que se ejecuta al guardar los cambios desde el instructor
-    // Se define como función nombrada para poder removerla después del submit
-    // y evitar que se acumule un listener por cada edición
-    async function guardarCambiosInstructor(event) {
-        event.preventDefault();
-
-        // Leer los valores actuales del formulario de edición
-        const tareaId     = document.getElementById('editTaskId').value;
-        const titulo      = document.getElementById('editTaskTitle').value.trim();
-        const descripcion = document.getElementById('editTaskDescription').value.trim();
-        const estado      = document.getElementById('editTaskStatus').value;
-
-        // El campo comentario puede no existir en todos los formularios de edición
-        const comentEl   = document.getElementById('editTaskComment');
-        const comentario = comentEl && comentEl.value.trim() !== ''
-            ? comentEl.value.trim()
-            : null;
-
-        // Construir el objeto con los datos actualizados
-        const datosActualizados = {
-            title:       titulo,
-            description: descripcion,
-            status:      estado,
-            comment:     comentario,
-        };
-
-        // Llamar al backend para actualizar la tarea
-        const tareaActualizada = await actualizarTarea(tareaId, datosActualizados);
-
-        if (tareaActualizada) {
-            // Cerrar el modal y recargar las tablas del instructor
-            ocultarModalEdicion();
-            // Se recargan ambas tablas para reflejar los cambios de forma consistente
-            cargarTareasInstructor();
-            cargarDashboardInstructor();
-            await mostrarNotificacion('Tarea actualizada exitosamente', 'exito');
-        } else {
-            await mostrarNotificacion('Error al actualizar la tarea', 'error');
-        }
-
-        // Remover el listener después de ejecutarse para evitar duplicados
-        // en la próxima edición desde el panel instructor
-        formulario.removeEventListener('submit', guardarCambiosInstructor);
-    }
-
-    // Registrar el listener del submit para esta edición del instructor
-    formulario.addEventListener('submit', guardarCambiosInstructor);
-}
 
 function crearFilaTareaAdmin(tarea, indice) {
     const fila = document.createElement('tr');

--- a/src/ui/modoUI.js
+++ b/src/ui/modoUI.js
@@ -392,9 +392,11 @@ function crearFilaTareaInstructor(tarea, indice) {
     btnEditar.textContent = '✏️ Editar';
     btnEditar.classList.add('btn-action', 'btn-action--edit');
     btnEditar.type = 'button';
-    btnEditar.addEventListener('click', function() {
-        // abrirModalEditarTarea usa el modal existente id="editModal" del index.html
-        abrirModalEditarTarea(tarea);
+       btnEditar.addEventListener('click', function() {
+        // manejarEdicionTareaInstructor abre el modal editModal con los datos de la tarea
+        // y registra el submit para que al guardar recargue la tabla del instructor.
+        // Se usa una función separada del admin para no afectar la lógica del admin.
+        manejarEdicionTareaInstructor(tarea);
     });
 
     // Botón Eliminar — pide confirmación antes de eliminar
@@ -1016,6 +1018,69 @@ function manejarEdicionTareaAdmin(tarea) {
     }
 
     formulario.addEventListener('submit', guardarCambiosAdmin);
+}
+
+// manejarEdicionTareaInstructor — abre el modal compartido de edición para el instructor.
+// Diferencia con manejarEdicionTareaAdmin:
+//   - Al guardar, recarga cargarTareasInstructor() y cargarDashboardInstructor()
+//   - No actualiza todasLasTareas (esa variable es privada del panel admin)
+// Usa el mismo modal editModal y el mismo formulario editTaskForm del index.html.
+function manejarEdicionTareaInstructor(tarea) {
+    // Abrir el modal con los datos de la tarea precargados
+    // mostrarModalEdicion viene de tareasUI.js y rellena los campos del formulario
+    mostrarModalEdicion(tarea);
+
+    // Referencia al formulario compartido de edición
+    const formulario = document.getElementById('editTaskForm');
+    if (!formulario) return;
+
+    // Función que se ejecuta al guardar los cambios desde el instructor
+    // Se define como función nombrada para poder removerla después del submit
+    // y evitar que se acumule un listener por cada edición
+    async function guardarCambiosInstructor(event) {
+        event.preventDefault();
+
+        // Leer los valores actuales del formulario de edición
+        const tareaId     = document.getElementById('editTaskId').value;
+        const titulo      = document.getElementById('editTaskTitle').value.trim();
+        const descripcion = document.getElementById('editTaskDescription').value.trim();
+        const estado      = document.getElementById('editTaskStatus').value;
+
+        // El campo comentario puede no existir en todos los formularios de edición
+        const comentEl   = document.getElementById('editTaskComment');
+        const comentario = comentEl && comentEl.value.trim() !== ''
+            ? comentEl.value.trim()
+            : null;
+
+        // Construir el objeto con los datos actualizados
+        const datosActualizados = {
+            title:       titulo,
+            description: descripcion,
+            status:      estado,
+            comment:     comentario,
+        };
+
+        // Llamar al backend para actualizar la tarea
+        const tareaActualizada = await actualizarTarea(tareaId, datosActualizados);
+
+        if (tareaActualizada) {
+            // Cerrar el modal y recargar las tablas del instructor
+            ocultarModalEdicion();
+            // Se recargan ambas tablas para reflejar los cambios de forma consistente
+            cargarTareasInstructor();
+            cargarDashboardInstructor();
+            await mostrarNotificacion('Tarea actualizada exitosamente', 'exito');
+        } else {
+            await mostrarNotificacion('Error al actualizar la tarea', 'error');
+        }
+
+        // Remover el listener después de ejecutarse para evitar duplicados
+        // en la próxima edición desde el panel instructor
+        formulario.removeEventListener('submit', guardarCambiosInstructor);
+    }
+
+    // Registrar el listener del submit para esta edición del instructor
+    formulario.addEventListener('submit', guardarCambiosInstructor);
 }
 
 function crearFilaTareaAdmin(tarea, indice) {

--- a/styles.css
+++ b/styles.css
@@ -1029,6 +1029,190 @@ body[data-modo="admin"]   { background-color: #e0f2fe; }
     border-color: var(--color-error) !important;
 }
 
+/* ── MODAL DE REGISTRO V2 — Rediseño M7 ────────────────────────────────────────
+   Clases nuevas con prefijo modal--registro-v2 para no afectar los estilos
+   del modal base (.modal, .modal__header, etc.) que usan los otros modales.
+   Todos los colores respetan la paleta del proyecto definida en :root. */
+
+/* Tarjeta del modal — más ancha que el modal base para acomodar el grid de 2 columnas */
+.modal--registro-v2 {
+    max-width:  520px;        /* Más ancho que el modal--registro original (420px) */
+    width:      95%;          /* En móvil usa casi todo el ancho disponible */
+    padding:    0;            /* El padding lo da cada sección internamente */
+    overflow:   hidden;       /* Para que el header con fondo de color no se salga */
+    border-radius: var(--radio-2xl);
+}
+
+/* Encabezado del modal — fondo con gradiente suave de la paleta del proyecto */
+.modal--registro-v2__header {
+    display:         flex;
+    align-items:     center;
+    gap:             var(--espacio-md);
+    padding:         var(--espacio-lg) var(--espacio-xl);
+    background:      linear-gradient(135deg, var(--color-primario-suave) 0%, #e0f2fe 100%);
+    border-bottom:   1px solid var(--borde-suave);
+    position:        relative;     /* Para el botón de cierre posicionado absolutamente */
+}
+
+/* Círculo con el ícono de usuario — da identidad visual al modal */
+.modal--registro-v2__icono {
+    width:           48px;
+    height:          48px;
+    border-radius:   50%;
+    background:      white;
+    border:          2px solid var(--color-primario);
+    display:         flex;
+    align-items:     center;
+    justify-content: center;
+    font-size:       1.5rem;
+    flex-shrink:     0;            /* No se encoge en layouts flex */
+    box-shadow:      var(--sombra-sm);
+}
+
+/* Título del modal en el header */
+.modal--registro-v2__titulo {
+    font-size:   var(--texto-xl);
+    font-weight: 700;
+    color:       var(--texto-oscuro);
+    margin:      0;
+}
+
+/* Subtítulo descriptivo debajo del título */
+.modal--registro-v2__subtitulo {
+    font-size:  var(--texto-sm);
+    color:      var(--texto-medio);
+    margin:     var(--espacio-xs) 0 0;
+}
+
+/* Botón X de cierre — posicionado en la esquina superior derecha del header */
+.modal--registro-v2__cerrar {
+    position:    absolute;
+    top:         var(--espacio-md);
+    right:       var(--espacio-md);
+    background:  none;
+    border:      none;
+    font-size:   var(--texto-lg);
+    color:       var(--texto-claro);
+    cursor:      pointer;
+    padding:     var(--espacio-xs);
+    border-radius: var(--radio-md);
+    line-height: 1;
+    transition:  color var(--transicion), background-color var(--transicion);
+}
+
+.modal--registro-v2__cerrar:hover {
+    color:            var(--texto-oscuro);
+    background-color: var(--borde-suave);
+}
+
+/* Formulario — padding interno y columna flex */
+.modal--registro-v2__form {
+    display:         flex;
+    flex-direction:  column;
+    gap:             var(--espacio-md);
+    padding:         var(--espacio-xl);
+}
+
+/* Fila de dos columnas para nombre+documento y contraseña+confirmar */
+.modal--registro-v2__fila {
+    display:   grid;
+    grid-template-columns: 1fr 1fr;   /* Dos columnas de igual tamaño */
+    gap:       var(--espacio-md);     /* Espacio entre las dos columnas */
+}
+
+/* Grupo de campo: label + input + span de error */
+.modal--registro-v2__grupo {
+    display:        flex;
+    flex-direction: column;
+    gap:            var(--espacio-xs);
+}
+
+/* Label del campo */
+.modal--registro-v2__label {
+    font-size:   var(--texto-sm);
+    font-weight: 600;
+    color:       var(--texto-oscuro);
+}
+
+/* Input del campo — hereda el estilo de .form__input pero con borde de color primario al focus */
+.modal--registro-v2__input {
+    width:         100%;
+    padding:       var(--espacio-sm) var(--espacio-md);
+    font-size:     var(--texto-md);
+    font-family:   var(--fuente);
+    color:         var(--texto-oscuro);
+    background:    white;
+    border:        2px solid var(--borde-suave);
+    border-radius: var(--radio-md);
+    transition:    border-color var(--transicion), box-shadow var(--transicion);
+    outline:       none;
+}
+
+.modal--registro-v2__input:focus {
+    border-color: var(--color-primario);
+    box-shadow:   0 0 0 3px var(--color-primario-suave);
+}
+
+.modal--registro-v2__input::placeholder {
+    color: var(--texto-claro);
+}
+
+/* Span de error con ícono de advertencia para feedback más claro */
+.modal--registro-v2__error {
+    font-size:  var(--texto-sm);
+    color:      var(--color-error);
+    min-height: 1.2em;              /* Reserva espacio para que el layout no salte */
+}
+
+/* Antes del texto del error se agrega un ícono de advertencia automáticamente */
+/* Solo se muestra si el span tiene contenido (la pseudoclase :not(:empty) lo activa) */
+.modal--registro-v2__error:not(:empty)::before {
+    content: '⚠ ';               /* Ícono de advertencia seguido de espacio */
+}
+
+/* Botón de envío — ocupa todo el ancho con el color primario del proyecto */
+.modal--registro-v2__btn-submit {
+    width:           100%;
+    padding:         var(--espacio-md) var(--espacio-lg);
+    background:      var(--color-primario);
+    color:           white;
+    border:          none;
+    border-radius:   var(--radio-lg);
+    font-size:       var(--texto-md);
+    font-weight:     600;
+    cursor:          pointer;
+    transition:      background-color var(--transicion), transform var(--transicion);
+    margin-top:      var(--espacio-sm);
+}
+
+.modal--registro-v2__btn-submit:hover {
+    background-color: var(--color-primario-oscuro);
+    transform:        translateY(-1px);
+}
+
+.modal--registro-v2__btn-submit:disabled {
+    opacity:  0.6;
+    cursor:   not-allowed;
+    transform: none;
+}
+
+/* Nota de privacidad al final del formulario */
+.modal--registro-v2__nota {
+    font-size:  var(--texto-sm);
+    color:      var(--texto-claro);
+    text-align: center;
+    margin:     0;
+}
+
+/* Responsividad: en móvil las dos columnas pasan a una */
+@media (max-width: 480px) {
+    .modal--registro-v2__fila {
+        grid-template-columns: 1fr;    /* Una sola columna en pantallas pequeñas */
+    }
+    .modal--registro-v2 {
+        max-width: 100%;
+    }
+}
 
 /* ANIMACIONES */
 @keyframes slideIn {


### PR DESCRIPTION
## Descripción del Cambio

Se implementaron mejoras en el repositorio frontend:

1. **Editar tarea instructor**Se implementó `manejarEdicionTareaInstructor` para que el botón editar del instructor abra el modal y guarde los cambios correctamente.
2. **Modal registro rediseñado** El modal de registro tiene un nuevo diseño con header degradado, ícono de usuario, grid de 2 columnas para los campos y spans de error con ícono de advertencia.

## Tipo de Cambio

- [x] fix: Corrección de bugs
- [x] style: Cambios visuales/CSS

## Relación con Tareas

Closes #101 
Closes #105 

## Checklist de Calidad Universal

- [x] Sincronización: he hecho `git pull origin release` antes de este PR
- [x] Limpieza: sin `console.log` ni comentarios de prueba
- [x] Estándares: nombres en camelCase, comentarios en español
- [x] No se usó `innerHTML` en ningún cambio de JavaScript

### Validación FRONTEND

- [x] El botón editar del instructor abre el modal con datos precargados y guarda correctamente
- [x] El modal de registro tiene el nuevo diseño (header degradado, grid 2 columnas)
- [x] El modal de registro es responsive en móvil (1 columna)

## Evidencia de Trabajo

> Adjuntar:

> 4. Screenshot del modal de edición abierto desde el panel instructor
<img width="1367" height="867" alt="image" src="https://github.com/user-attachments/assets/b5a68211-3dcc-4a7a-8937-9ed44c90072d" />

> 8. Screenshot del modal de registro con el nuevo diseño
<img width="731" height="727" alt="image" src="https://github.com/user-attachments/assets/8db04c9e-dc64-41a1-b117-4dff28f23404" />
