### PR TITLE
fix(M12-frontend): correcciones UI, comportamiento visual y persistencia de motivo de desactivación

### DIFF
--- a/src/ui/modoUI.js
+++ b/src/ui/modoUI.js
@@ -375,38 +375,36 @@ export async function activarModoUsuario() {
     if (!tbody) return;
     while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
 
-    if (!tareas || tareas.length === 0) {
-        // Mostrar estado vacío si no hay tareas asignadas
+        if (!tareas || tareas.length === 0) {
+        // Mostrar estado vacío solo en la tabla — el calendario y las notas siguen activos
         const estadoVacio = document.getElementById('tasksEmptyState');
         if (estadoVacio) estadoVacio.classList.remove('hidden');
-        return;
+    } else {
+        // Ocultar el estado vacío y pintar cada tarea
+        const estadoVacio = document.getElementById('tasksEmptyState');
+        if (estadoVacio) estadoVacio.classList.add('hidden');
+
+        tareas.forEach(function(tarea, indice) {
+            // agregarTareaATabla viene de tareasUI.js y construye la fila con createElement
+            agregarTareaATabla(tarea, indice);
+        });
     }
 
-    // Ocultar el estado vacío y pintar cada tarea
-    const estadoVacio = document.getElementById('tasksEmptyState');
-    if (estadoVacio) estadoVacio.classList.add('hidden');
-
-    tareas.forEach(function(tarea, indice) {
-        // agregarTareaATabla viene de tareasUI.js y construye la fila con createElement
-        agregarTareaATabla(tarea, indice);
-    });
-
     // Cargar el dashboard de estadísticas del panel usuario.
-    // Se llama con los IDs del vistaUsuario (prefijo userDash) para no
-    // sobreescribir los valores del dashboard del panel admin.
-    cargarDashboardUsuario(tareas);   // pasar tareas ya cargadas, no hacer fetch extra
+    // Se llama siempre — cargarDashboardUsuario maneja el caso de arreglo vacío
+    cargarDashboardUsuario(tareas || []);
 
-    // Montar el calendario del usuario:
-    // soloLectura: false — el usuario puede agregar eventos propios además de ver los del instructor
+    // Montar el calendario del usuario SIEMPRE — se muestra aunque no haya tareas.
+    // crearCalendario acepta tareas=[] y renderiza el calendario completo sin puntos.
     await crearCalendario({
         contenedorId: 'usuarioCalendario',
         paleta:       'usuario',
         soloLectura:  false,
-        tareas:       tareas,
+        tareas:       tareas || [],
         userId:       usuarioSesion.id,   // para restringir borrado a eventos propios
     });
 
-    // Cargar los post-its personales
+    // Cargar los post-its personales SIEMPRE — no dependen de las tareas asignadas
     cargarPostits(usuarioSesion.id);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -430,7 +430,7 @@ body[data-modo="admin"]   {
 
 .card--usuario-info .user-info__label {
     font-size: 0.72rem;
-    font-weight: 700;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--texto-claro);
@@ -439,10 +439,10 @@ body[data-modo="admin"]   {
 }
 
 .card--usuario-info .user-info__value {
-    font-size: 1.1rem;
-    font-weight: 700;
+    font-size: 0.95rem;
+    font-weight: 500;
     color: var(--texto-oscuro);
-    letter-spacing: -0.01em;
+    letter-spacing: 0;
 }
 
 /* La fila de promedio ocupa las dos columnas */

--- a/styles.css
+++ b/styles.css
@@ -709,7 +709,8 @@ body[data-modo="admin"]   {
 .status-reprobada   { background: #fee2e2; color: #991b1b; font-weight: 700; }
 /* Badge para el cuarto estado: naranja suave, diferente del amarillo de "pendiente" */
 /* Fondo #ffedd5 (naranja claro) — texto #9a3412 (naranja oscuro con buen contraste) */
-.status-pendiente_aprobacion { background: #ffedd5; color: #9a3412; font-size: 0.78rem; white-space: nowrap; }
+/* Sin font-size propio — hereda var(--texto-sm) de .status-badge para ser igual a los demás */
+.status-pendiente_aprobacion { background: #ffedd5; color: #9a3412; }
 /* Badge para usuario inactivo (borrado suave) */
 .status-inactivo { background: #f1f5f9; color: #64748b; font-size: 0.75rem; }
 


### PR DESCRIPTION
## Descripción del Cambio
Consolidación de algunas de las correcciones del Milestone 12 en el repositorio frontend (transferencia_dom): corrección del calendario y notas en vista usuario sin tareas asignadas, reducción del peso tipográfico en la card de datos del usuario, uniformización del tamaño de todos los badges de estado.

## Relación con Tareas
**Vínculo:** Closes #148 
                    Closes #150 
                    Closes #152 
---
#### Tipo de Cambio

- [x] `fix` — Corrección de error.
- [ ] `feat` — Nueva funcionalidad.
- [ ] `docs` / `style` — Documentación o formato.
- [ ] `refactor` — Mejora de código (sin cambios funcionales).
---
#### Checklist de Calidad Universal

- [x] Sincronización: He actualizado mi rama con `origin/developer` y resolví conflictos.
- [x] Limpieza: Sin `console.log`, comentarios de prueba o archivos `.env`.
- [x] Estándares: Uso de JSDoc para funciones y nombres de variables en camelCase.

---

#### Validación FRONTEND
- [x] Componentización: El código se separó en componentes reutilizables (si aplica).

#### Validación BACKEND *(No aplica para este PR — los cambios de backend van en su propio PR)*

---

#### Evidencia de Trabajo

*Adjunta un screenshot (Frontend) por cada corrección visual aplicada:*

- Captura de la vista usuario sin tareas asignadas mostrando el calendario y las notas (Issue 2)
<img width="1256" height="873" alt="image" src="https://github.com/user-attachments/assets/172eac3e-c2fc-4442-9982-bd2e1ec1d65c" />

- Captura de la card de datos del usuario con tipografía reducida (Issue 5)

<img width="910" height="360" alt="image" src="https://github.com/user-attachments/assets/3518070f-46fd-4daa-9b64-7fa8da317f68" />

- Captura de los cinco badges de estado con tamaño uniforme (Issue 7)
<img width="791" height="461" alt="image" src="https://github.com/user-attachments/assets/d2fcbf49-c527-469e-88c4-c5936a9d948e" />

---